### PR TITLE
Allow setting all arguments for chat.postMessage

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -8,7 +8,12 @@ Use this to as an interface to the Slack web API.
     var SlackAttack = require('slack-attack');
     var slack = new SlackAttack('<YOUR-API-KEY>');
 
-    slack.chat('#<channel>', '<message>', {options}, function(err, posted, resp){
+    var options = { 'username': 'Test Bot',
+                    'icon_emoji': ':robot_face:',
+                    'link_names': 1 };
+
+
+    slack.chat('#<channel>', '<message>', options, function(err, posted, resp){
       console.log(err, posted, resp);
     });
 ```

--- a/src/index.js
+++ b/src/index.js
@@ -29,11 +29,15 @@ SlackAttack.prototype.chat = function(channel, message, options, callback){
   var payload = {
     channel: channel,
     text: message,
-    icon_emoji: options.icon_emoji,
   }
 
-  if (options.attachments instanceof Array)
-    payload.attachments = JSON.stringify(options.attachments)
+  for (var attrname in options) {
+    if (options.attachments instanceof Array) {
+      payload.attachments = JSON.stringify(options.attachments)
+    } else {
+      payload[attrname] = options[attrname];
+    }
+  }
 
   this.api("chat.postMessage", payload, callback);
 }


### PR DESCRIPTION
Small PR allowing the use of extra options for chat.postMessage, so bot name and other parameters can be changed too.
